### PR TITLE
[#44] 복구: Avoid Mutable Globals 섹션 번역 복원

### DIFF
--- a/README.md
+++ b/README.md
@@ -1269,6 +1269,82 @@ func (f *foo) isRunning() bool {
 </td></tr>
 </tbody></table>
 
+### 변경 가능한(mutable) 전역변수 피하기 (Avoid Mutable Globals)
+
+전역 변수를 변경하는 것을 피하고, 대신 의존성 주입(dependency injection)을 선택하라. 이는 함수 포인터뿐만 아니라 다른 종류의 값에도 적용된다.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+// sign.go
+
+var _timeNow = time.Now
+
+func sign(msg string) string {
+  now := _timeNow()
+  return signWithTime(msg, now)
+}
+```
+
+</td><td>
+
+```go
+// sign.go
+
+type signer struct {
+  now func() time.Time
+}
+
+func newSigner() *signer {
+  return &signer{
+    now: time.Now,
+  }
+}
+
+func (s *signer) Sign(msg string) string {
+  now := s.now()
+  return signWithTime(msg, now)
+}
+```
+
+</td></tr>
+<tr><td>
+
+```go
+// sign_test.go
+
+func TestSign(t *testing.T) {
+  oldTimeNow := _timeNow
+  _timeNow = func() time.Time {
+    return someFixedTime
+  }
+  defer func() { _timeNow = oldTimeNow }()
+
+  assert.Equal(t, want, sign(give))
+}
+```
+
+</td><td>
+
+```go
+// sign_test.go
+
+func TestSigner(t *testing.T) {
+  s := newSigner()
+  s.now = func() time.Time {
+    return someFixedTime
+  }
+
+  assert.Equal(t, want, s.Sign(give))
+}
+```
+
+</td></tr>
+</tbody></table>
+
 ### Main에서 종료하기 (Exit in Main)
 
 Go 프로그램은 즉시 종료하기 위해 [`os.Exit`](https://pkg.go.dev/os#Exit) 또는 [`log.Fatal*`](https://pkg.go.dev/log#Fatal)을 사용한다. (패닉은 프로그램을 종료하는 좋은 방법이 아니다. [패닉을 피할 것](#패닉을-피할-것-dont-panic)을 참고하라.)


### PR DESCRIPTION
## 개요
PR #41 머지 시 충돌 해결 과정에서 유실된 `### 변경 가능한(mutable) 전역변수 피하기` 섹션을 복구합니다.

## 복구된 섹션
- `### 변경 가능한(mutable) 전역변수 피하기 (Avoid Mutable Globals)`
  - 의존성 주입을 통한 전역 변수 변경 회피 패턴
  - sign.go / sign_test.go Bad/Good 2행 비교 표

## 삽입 위치
`### go.uber.org/atomic의 사용` 와 `### Main에서 종료하기` 사이 (원문과 동일)

Closes #44