### PR TITLE
[#55] fix: Error Wrapping 코드 오류 수정 (%s → %w)

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,7 +911,7 @@ if err := foo.Open("foo"); err != nil {
 s, err := store.New()
 if err != nil {
     return fmt.Errorf(
-        "failed to create new store: %s", err)
+        "failed to create new store: %w", err)
 }
 ```
 
@@ -921,7 +921,7 @@ if err != nil {
 s, err := store.New()
 if err != nil {
     return fmt.Errorf(
-        "new store: %s", err)
+        "new store: %w", err)
 }
 ```
 


### PR DESCRIPTION
## 문제
`fmt.Errorf`로 에러를 래핑할 때 `%s` 대신 `%w`를 사용해야 합니다.
`%s`를 사용하면 `errors.Is`/`errors.As`로 언래핑이 불가능하여 잘못된 코드입니다.

## 변경
```go
// Before (오류)
return fmt.Errorf("failed to create new store: %s", err)
return fmt.Errorf("new store: %s", err)

// After (수정)
return fmt.Errorf("failed to create new store: %w", err)
return fmt.Errorf("new store: %w", err)
```

## 원문 확인
https://github.com/uber-go/guide/blob/master/style.md#error-wrapping

Closes #55