### PR TITLE
[#56] fix: Don't Panic 예시 코드 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,40 +1135,33 @@ fine. -->
 <tr><td>
 
 ```go
-func foo(bar string) {
-  if len(bar) == 0 {
-    panic("bar must not be empty")
+func run(args []string) {
+  if len(args) == 0 {
+    panic("an argument is required")
   }
   // ...
 }
 
 func main() {
-  if len(os.Args) != 2 {
-    fmt.Println("USAGE: foo <bar>")
-    os.Exit(1)
-  }
-  foo(os.Args[1])
+  run(os.Args[1:])
 }
 ```
 
 </td><td>
 
 ```go
-func foo(bar string) error {
-  if len(bar) == 0 {
-    return errors.New("bar must not be empty")
+func run(args []string) error {
+  if len(args) == 0 {
+    return errors.New("an argument is required")
   }
   // ...
   return nil
 }
 
 func main() {
-  if len(os.Args) != 2 {
-    fmt.Println("USAGE: foo <bar>")
+  if err := run(os.Args[1:]); err != nil {
+    fmt.Fprintln(os.Stderr, err)
     os.Exit(1)
-  }
-  if err := foo(os.Args[1]); err != nil {
-    panic(err)
   }
 }
 ```
@@ -1192,7 +1185,7 @@ var _statusTemplate = template.Must(template.New("name").Parse("_statusHTML"))
 ```go
 // func TestFoo(t *testing.T)
 
-f, err := ioutil.TempFile("", "test")
+f, err := os.CreateTemp("", "test")
 if err != nil {
   panic("failed to set up test")
 }
@@ -1203,7 +1196,7 @@ if err != nil {
 ```go
 // func TestFoo(t *testing.T)
 
-f, err := ioutil.TempFile("", "test")
+f, err := os.CreateTemp("", "test")
 if err != nil {
   t.Fatal("failed to set up test")
 }


### PR DESCRIPTION
## 변경 사항

### 1. 함수 시그니처 원문 복원
- `foo(bar string)` → `run(args []string)` (원문 기준)
- main에서 `fmt.Fprintln(os.Stderr, err)` + `os.Exit(1)` 패턴 사용

### 2. Deprecated API 교체
- `ioutil.TempFile` → `os.CreateTemp` (Go 1.16에서 deprecated)
- Bad/Good 코드 블록 모두 수정

Closes #56