### PR TITLE
improve: CHANGELOG 업데이트 + CONTRIBUTING.md + GitHub Actions 추가

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -1,0 +1,70 @@
+name: 원본 업데이트 감지 (Check Upstream)
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # 매주 월요일 오전 9시 (UTC)
+  workflow_dispatch:       # 수동 실행 가능
+
+jobs:
+  check-upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 리포 체크아웃
+        uses: actions/checkout@v4
+
+      - name: 원본 CHANGELOG 가져오기
+        id: upstream
+        run: |
+          curl -s https://raw.githubusercontent.com/uber-go/guide/master/CHANGELOG.md \
+            -o /tmp/upstream_changelog.md
+          LATEST=$(grep -m1 '^# ' /tmp/upstream_changelog.md | sed 's/# //')
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+          echo "원본 최신 날짜: $LATEST"
+
+      - name: 번역 리포 기준 날짜 확인
+        id: translation
+        run: |
+          CURRENT=$(grep -m1 '원문 기준:' CHANGELOG.md | grep -oP '\d{4}-\d{2}-\d{2}' | head -1 || echo "unknown")
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          echo "번역 기준 날짜: $CURRENT"
+
+      - name: 차이 비교 및 이슈 생성
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST="${{ steps.upstream.outputs.latest }}"
+          CURRENT="${{ steps.translation.outputs.current }}"
+
+          echo "원본 최신: $LATEST / 번역 기준: $CURRENT"
+
+          # 날짜 비교 (원본이 더 최신이면 이슈 생성)
+          if [ "$LATEST" \> "$CURRENT" ]; then
+            # 이미 동일 제목의 이슈가 있는지 확인
+            EXISTING=$(gh issue list --label "upstream-update" --state open --json title --jq ".[].title" | grep "$LATEST" || true)
+            if [ -z "$EXISTING" ]; then
+              CHANGES=$(sed -n "/^# $LATEST/,/^# /p" /tmp/upstream_changelog.md | grep '^-' | head -20)
+              gh issue create \
+                --title "[원본 업데이트] uber-go/guide $LATEST 변경 사항 번역 필요" \
+                --label "documentation,upstream-update" \
+                --body "## 원본 업데이트 감지
+
+원본 [uber-go/guide](https://github.com/uber-go/guide) 리포지토리가 **$LATEST** 에 업데이트되었습니다.
+현재 번역 기준: **$CURRENT**
+
+## 변경 사항
+
+$CHANGES
+
+## 참고 링크
+- [원본 CHANGELOG](https://github.com/uber-go/guide/blob/master/CHANGELOG.md)
+- [원본 style.md](https://github.com/uber-go/guide/blob/master/style.md)
+
+---
+*이 이슈는 GitHub Actions에 의해 자동 생성되었습니다.*"
+              echo "✅ 이슈 생성 완료"
+            else
+              echo "ℹ️ 이미 동일 이슈가 존재합니다"
+            fi
+          else
+            echo "✅ 번역이 최신 상태입니다"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # CHANGELOG
 
+## 2026/06/07
+
+원문 기준: [2023-05-09](https://github.com/uber-go/guide/blob/master/CHANGELOG.md#2023-05-09)까지 반영
+
+### 코드 오류 수정
+- Error Wrapping: `%s` → `%w` 코드 오류 수정 ([#60](https://github.com/TangoEnSkai/uber-go-style-guide-kr/pull/60))
+- Don't Panic: deprecated `ioutil.TempFile` → `os.CreateTemp`, 예시 코드 원문 복원 ([#61](https://github.com/TangoEnSkai/uber-go-style-guide-kr/pull/61))
+
+### 누락 내용 복구 및 업데이트
+- Embedding in Structs: 임베딩 금지 조건 12가지 및 코드 예시 복구 ([#62](https://github.com/TangoEnSkai/uber-go-style-guide-kr/pull/62))
+- Reduce Scope of Variables: 상수 스코프 예시 추가 ([#63](https://github.com/TangoEnSkai/uber-go-style-guide-kr/pull/63))
+- Functional Options: struct 기반 Option 패턴으로 전면 업데이트 ([#64](https://github.com/TangoEnSkai/uber-go-style-guide-kr/pull/64))
+
+### 신규 번역 (원문 2019-10-21 ~ 2023-05-09)
+- Errors 섹션 재편 + Error Naming, Handle Errors Once
+- Exit in Main / Exit Once
+- Use field tags in marshaled structs
+- Don't fire-and-forget goroutines
+- Prefer Specifying Container Capacity (Map/Slice 힌트)
+- Style: Avoid overly long lines, Be Consistent, Initializing Maps
+- Style: Initializing Structs 서브섹션 재편
+- Patterns: Test Tables 서브섹션 (Avoid Unnecessary Complexity, Parallel Tests)
+- Linting 섹션 전체
+
+### 스타일 통일
+- 구형 번역 헤딩 6개에 영문 병기 추가 (`### 한국어 (English)` 형식)
+
 ## 2022/06/07
 
 - Introduction 부분 내용 업데이트 및 재번역

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# 기여 가이드 (Contributing Guide)
+
+이 리포지토리는 [uber-go/guide](https://github.com/uber-go/guide)의 한국어 번역입니다.
+기여를 환영합니다! 아래 가이드를 따라 주세요.
+
+---
+
+## 번역 규칙
+
+### 1. 헤딩 형식
+모든 섹션 헤딩은 **한국어 번역 + 영문 원문** 형식을 사용합니다.
+
+```markdown
+### 한국어 번역 (English Original)
+```
+
+예시:
+```markdown
+### 에러를 한 번만 처리하라 (Handle Errors Once)
+### 컨테이너 용량 지정을 선호하라 (Prefer Specifying Container Capacity)
+```
+
+### 2. 코드 블록
+- **코드 자체는 원문과 100% 동일하게 유지**합니다. 절대 수정하지 마세요.
+- **코드 내 주석은 한국어로 번역**합니다.
+
+```go
+// Good: 한국어 주석
+func isActive(now, start, stop time.Time) bool {
+  return (start.Before(now) || start.Equal(now)) && now.Before(stop)
+}
+```
+
+### 3. 기술 용어
+아래 용어는 번역하지 않고 원어를 사용합니다:
+
+| 번역 금지 용어 |
+|---|
+| goroutine, mutex, channel, struct, interface |
+| slice, map, pointer, receiver, embedding |
+| package, import, defer, panic |
+| Bad / Good (표 헤더) |
+
+### 4. 표 형식
+Bad/Good 비교 표는 원문의 HTML 테이블 구조를 그대로 유지합니다.
+
+```html
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+...
+</td><td>
+...
+</td></tr>
+</tbody></table>
+```
+
+---
+
+## PR 작성 방법
+
+### 브랜치 명명 규칙
+```
+fix/issue-{번호}-{간단한설명}
+feat/issue-{번호}-{간단한설명}
+style/issue-{번호}-{간단한설명}
+```
+
+### 커밋 메시지 형식
+```
+fix(docs): 변경 내용 요약 (closes #이슈번호)
+feat(docs): 변경 내용 요약 (closes #이슈번호)
+style(docs): 변경 내용 요약 (closes #이슈번호)
+```
+
+### PR 체크리스트
+PR을 올리기 전에 아래를 확인해 주세요:
+
+- [ ] 원문([uber-go/guide](https://github.com/uber-go/guide/blob/master/style.md))과 번역 내용 대조
+- [ ] 코드 블록이 원문과 100% 동일한지 확인
+- [ ] 헤딩 형식이 `### 한국어 (English)` 형식인지 확인
+- [ ] 관련 이슈 번호가 PR body에 포함되었는지 확인
+
+---
+
+## 원본 업데이트 추적
+
+원본 리포의 변경사항은 [CHANGELOG.md](https://github.com/uber-go/guide/blob/master/CHANGELOG.md)에서 확인할 수 있습니다.
+
+번역 리포의 현재 반영 기준은 이 리포의 [CHANGELOG.md](./CHANGELOG.md)를 참고하세요.
+
+---
+
+## 이슈 작성
+
+번역 오류, 누락, 개선 제안은 이슈로 등록해 주세요.
+
+이슈 제목 형식:
+```
+[번역] 섹션명: 문제 설명
+[오류] 섹션명: 코드/내용 오류 설명
+[내용 누락] 섹션명: 누락된 내용 설명
+```


### PR DESCRIPTION
## 변경 사항

### CHANGELOG.md
- 2026/06/07 기준으로 이번 세션에서 진행한 모든 작업 이력 추가

### CONTRIBUTING.md (신규)
- 헤딩 형식, 코드 블록, 기술 용어, 표 형식 규칙
- PR 브랜치 명명 / 커밋 메시지 형식
- PR 체크리스트
- 이슈 작성 형식

### .github/workflows/check-upstream.yml (신규)
- 매주 월요일 자동으로 원본 `uber-go/guide` CHANGELOG 확인
- 번역 기준 날짜보다 원본이 더 최신이면 자동으로 이슈 생성
- `workflow_dispatch`로 수동 실행도 가능