### PR TITLE
[#66] fix: Group Similar Declarations Exception 규칙 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -2373,6 +2373,42 @@ func f() string {
 </td></tr>
 </tbody></table>
 
+예외: 함수 내부에서 변수 선언은, 인접한 다른 변수들과 함께 선언되는 경우 묶어서 그룹화해야 한다. 서로 관련이 없더라도 함께 선언된 변수라면 이렇게 하라.
+
+<table>
+<thead><tr><th>Bad</th><th>Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+func (c *client) request() {
+  caller := c.name
+  format := "json"
+  timeout := 5*time.Second
+  var err error
+
+  // ...
+}
+```
+
+</td><td>
+
+```go
+func (c *client) request() {
+  var (
+    caller  = c.name
+    format  = "json"
+    timeout = 5*time.Second
+    err error
+  )
+
+  // ...
+}
+```
+
+</td></tr>
+</tbody></table>
+
 ### Import 그룹 정리/배치 (Import Group Ordering)
 
 2가지 import 그룹들이 존재한다:


### PR DESCRIPTION
## 변경 사항

함수 내부 변수 선언 그룹화 예외 규칙과 코드 예시 2개 추가.

**추가된 내용:**
- 예외 설명: 인접한 변수 선언은 관련 여부와 무관하게 `var (...)`로 묶어 그룹화
- Bad: `:=`로 개별 선언된 변수들
- Good: `var (...)`로 묶은 변수들

Closes #66