### PR TITLE
[#97] fix: Receivers and Interfaces 코드 주석 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,17 +269,25 @@ func (s *S) Write(str string) {
   s.data = str
 }
 
+// We cannot get pointers to values stored in maps, because they are not
+// addressable values.
 sVals := map[int]S{1: {"A"}}
 
-// You can only call Read using a value
+// We can call Read on values stored in the map because Read
+// has a value receiver, which does not require the value to
+// be addressable.
 sVals[1].Read()
 
-// This will not compile:
+// We cannot call Write on values stored in the map because Write
+// has a pointer receiver, and it's not possible to get a pointer
+// to a value stored in a map.
+//
 //  sVals[1].Write("test")
 
 sPtrs := map[int]*S{1: {"A"}}
 
-// You can call both Read and Write using a pointer
+// You can call both Read and Write if the map stores pointers,
+// because pointers are intrinsically addressable.
 sPtrs[1].Read()
 sPtrs[1].Write("test")
 ```


### PR DESCRIPTION
## 변경 사항

2023-03-03 원문 업데이트("Clarify subtlety with pointer receivers and values")를 반영하여 코드 블록의 영문 주석을 최신화.

**핵심 변경:**
- 맵에 저장된 값의 포인터를 얻을 수 없는 이유(주소 지정 불가) 명시
- 값 리시버는 주소 지정이 필요 없다는 설명 추가
- 포인터 리시버는 맵 값에서 사용 불가한 이유 상세 설명 추가

Closes #97