### PR TITLE
[#117] fix: GitHub Actions style.md SHA 비교 추가

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -21,6 +21,21 @@ jobs:
           echo "latest=$LATEST" >> $GITHUB_OUTPUT
           echo "원본 최신 날짜: $LATEST"
 
+      - name: 원본 style.md SHA 확인
+        id: sha
+        run: |
+          # 원본 style.md 현재 SHA 가져오기
+          UPSTREAM_SHA=$(curl -s "https://api.github.com/repos/uber-go/guide/contents/style.md" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" | \
+            python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('sha','unknown'))")
+          echo "upstream_sha=$UPSTREAM_SHA" >> $GITHUB_OUTPUT
+          echo "원본 style.md SHA: $UPSTREAM_SHA"
+
+          # 번역 리포에 저장된 마지막 동기화 SHA 읽기
+          SAVED_SHA=$(cat .github/upstream-sha.txt 2>/dev/null || echo "none")
+          echo "saved_sha=$SAVED_SHA" >> $GITHUB_OUTPUT
+          echo "저장된 SHA: $SAVED_SHA"
+
       - name: 번역 리포 기준 날짜 확인
         id: translation
         run: |
@@ -34,15 +49,39 @@ jobs:
         run: |
           LATEST="${{ steps.upstream.outputs.latest }}"
           CURRENT="${{ steps.translation.outputs.current }}"
+          UPSTREAM_SHA="${{ steps.sha.outputs.upstream_sha }}"
+          SAVED_SHA="${{ steps.sha.outputs.saved_sha }}"
 
           echo "원본 최신: $LATEST / 번역 기준: $CURRENT"
+          echo "원본 SHA: $UPSTREAM_SHA / 저장 SHA: $SAVED_SHA"
 
-          # 날짜 비교 (원본이 더 최신이면 이슈 생성)
+          CHANGELOG_CHANGED=false
+          SHA_CHANGED=false
+
+          # CHANGELOG 날짜 비교
           if [ "$LATEST" \> "$CURRENT" ]; then
-            # 이미 동일 제목의 이슈가 있는지 확인
-            EXISTING=$(gh issue list --label "upstream-update" --state open --json title --jq ".[].title" | grep "$LATEST" || true)
+            CHANGELOG_CHANGED=true
+          fi
+
+          # SHA 비교 (CHANGELOG에 없는 변경 감지)
+          if [ "$UPSTREAM_SHA" != "$SAVED_SHA" ] && [ "$SAVED_SHA" != "none" ]; then
+            SHA_CHANGED=true
+          fi
+
+          if [ "$CHANGELOG_CHANGED" = "true" ] || [ "$SHA_CHANGED" = "true" ]; then
+            EXISTING=$(gh issue list --label "upstream-update" --state open --json title \
+              --jq ".[].title" | grep "$LATEST" || true)
+
             if [ -z "$EXISTING" ]; then
               CHANGES=$(sed -n "/^# $LATEST/,/^# /p" /tmp/upstream_changelog.md | grep '^-' | head -20)
+
+              EXTRA_NOTE=""
+              if [ "$SHA_CHANGED" = "true" ]; then
+                EXTRA_NOTE="
+> ⚠️ **참고**: style.md SHA가 변경되었으나 CHANGELOG에 반영되지 않았을 수 있습니다. 원본을 직접 확인해 주세요.
+> SHA: \`$SAVED_SHA\` → \`$UPSTREAM_SHA\`"
+              fi
+
               gh issue create \
                 --title "[원본 업데이트] uber-go/guide $LATEST 변경 사항 번역 필요" \
                 --label "documentation,upstream-update" \
@@ -50,6 +89,7 @@ jobs:
 
 원본 [uber-go/guide](https://github.com/uber-go/guide) 리포지토리가 **$LATEST** 에 업데이트되었습니다.
 현재 번역 기준: **$CURRENT**
+$EXTRA_NOTE
 
 ## 변경 사항
 
@@ -65,6 +105,26 @@ $CHANGES
             else
               echo "ℹ️ 이미 동일 이슈가 존재합니다"
             fi
+
+            # SHA 업데이트 커밋
+            if [ "$SHA_CHANGED" = "true" ] || [ "$SAVED_SHA" = "none" ]; then
+              echo "$UPSTREAM_SHA" > .github/upstream-sha.txt
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              git add .github/upstream-sha.txt
+              git commit -m "chore: upstream style.md SHA 업데이트 ($UPSTREAM_SHA)" || true
+              git push || true
+            fi
           else
             echo "✅ 번역이 최신 상태입니다"
+
+            # 초기 SHA 저장 (파일이 없는 경우)
+            if [ "$SAVED_SHA" = "none" ]; then
+              echo "$UPSTREAM_SHA" > .github/upstream-sha.txt
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              git add .github/upstream-sha.txt
+              git commit -m "chore: upstream style.md SHA 초기 저장 ($UPSTREAM_SHA)" || true
+              git push || true
+            fi
           fi


### PR DESCRIPTION
## 변경 사항
- 원본 `style.md`의 Git SHA를 `.github/upstream-sha.txt`에 저장
- 매주 실행 시 SHA 비교 → CHANGELOG 미반영 변경도 감지
- SHA 변경 시 이슈 본문에 SHA 변경 경고 추가
- SHA 변경 시 자동으로 `upstream-sha.txt` 업데이트 커밋

Closes #117